### PR TITLE
Fix Compilation Errors on some embedded platforms

### DIFF
--- a/src/alsa.rs
+++ b/src/alsa.rs
@@ -129,7 +129,7 @@ impl PCM {
         assert_eq!(::std::mem::size_of::<T>(), self.sample_fmt.size());
 
         Ok(unsafe {
-            let frames = ffi::snd_pcm_writei(self.i, buffer.as_ptr() as *const libc::c_void, buffer.len() as u64 / channels as u64);
+            let frames = ffi::snd_pcm_writei(self.i, buffer.as_ptr() as *const libc::c_void, buffer.len() as u32 / channels as u32);
             if frames < 0 {
                 alsa_ok!(ffi::snd_pcm_recover(self.i, frames as libc::c_int, 0)) as usize
             } else {


### PR DESCRIPTION
u64 thows:

15:43:22 /var/lib/jenkins/.cargo/git/checkouts/rust-alsa-31a8c45375350275/master/src/alsa.rs:132:94: 132:131 error: mismatched types:
15:43:22  expected `u32`,
15:43:22     found `u64` [E0308]
15:43:22 /var/lib/jenkins/.cargo/git/checkouts/rust-alsa-31a8c45375350275/master/src/alsa.rs:132             let frames = ffi::snd_pcm_writei(self.i, buffer.as_ptr() as *const libc::c_void, buffer.len() as u64 / channels as u64);

thanks to @joerg-krause
