### PR TITLE
fix borrow immutable anonymous field self.0

### DIFF
--- a/src/alsa.rs
+++ b/src/alsa.rs
@@ -122,7 +122,7 @@ impl PCM {
 }
 
 impl PCM {
-    pub fn write_interleaved<T: Copy>(&mut self, buffer: &[T]) -> Result<usize, isize> {
+    pub fn write_interleaved<T: Copy>(&self, buffer: &[T]) -> Result<usize, isize> {
         let channels = self.channels;
 
         assert_eq!(buffer.len() % channels, 0);


### PR DESCRIPTION
Needed to use rust-alsa with recent versions of librespot.
